### PR TITLE
feat: Ensure Lambda test workflows fail on non-200 status codes.

### DIFF
--- a/.github/workflows/bobaedream-extract-test.yml
+++ b/.github/workflows/bobaedream-extract-test.yml
@@ -98,3 +98,12 @@ jobs:
           response.json \
           --region ap-northeast-2 
         cat response.json
+        
+        # JSON에서 statusCode 추출
+        STATUS_CODE=$(jq '.statusCode' response.json)
+
+        # statusCode가 200이 아닌 경우 실패로 처리
+        if [ "$STATUS_CODE" -ne 200 ]; then
+          echo "Lambda invocation failed with statusCode: $STATUS_CODE"
+          exit 1
+        fi

--- a/.github/workflows/clien-extract-test.yml
+++ b/.github/workflows/clien-extract-test.yml
@@ -100,3 +100,12 @@ jobs:
           response.json \
           --region ap-northeast-2 
         cat response.json
+        
+        # JSON에서 statusCode 추출
+        STATUS_CODE=$(jq '.statusCode' response.json)
+
+        # statusCode가 200이 아닌 경우 실패로 처리
+        if [ "$STATUS_CODE" -ne 200 ]; then
+          echo "Lambda invocation failed with statusCode: $STATUS_CODE"
+          exit 1
+        fi

--- a/.github/workflows/dcinside-extract-test.yml
+++ b/.github/workflows/dcinside-extract-test.yml
@@ -98,4 +98,14 @@ jobs:
           --payload '{ "car_id": "test-github", "keywords": ["캐스퍼"], "date":"2025-02-10", "batch":3,"start_datetime": "2025-02-08T00:00:00", "end_datetime": "2025-02-11T00:00:00", "bucket": "${{ secrets.AWS_TEST_BUCKET_NAME }}"}' \
           response.json \
           --region ap-northeast-2 
-        cat response.json
+        cat response.json       
+        
+        # JSON에서 statusCode 추출
+        STATUS_CODE=$(jq '.statusCode' response.json)
+
+        # statusCode가 200이 아닌 경우 실패로 처리
+        if [ "$STATUS_CODE" -ne 200 ]; then
+          echo "Lambda invocation failed with statusCode: $STATUS_CODE"
+          exit 1
+        fi
+


### PR DESCRIPTION
Added a check in all test workflows (clien, dcinside, and bobaedream) to extract the `statusCode` from the Lambda response. The workflow now exits with failure if the `statusCode` is not 200, improving error detection during tests.