### PR TITLE
fix: Add CLI read timeout to AWS Lambda invoke commands

### DIFF
--- a/.github/workflows/bobaedream-extract-test.yml
+++ b/.github/workflows/bobaedream-extract-test.yml
@@ -97,7 +97,8 @@ jobs:
           --cli-binary-format raw-in-base64-out \
           --payload '{ "car_id": "test-github", "keywords": ["캐스퍼"], "date":"2025-02-10", "batch":3,"start_datetime": "2025-02-08T00:00:00", "end_datetime": "2025-02-11T00:00:00", "bucket": "${{ secrets.AWS_TEST_BUCKET_NAME }}"}' \
           response.json \
-          --region ap-northeast-2 
+          --region ap-northeast-2 \
+          --cli-read-timeout 840
         cat response.json
         
         # JSON에서 statusCode 추출

--- a/.github/workflows/clien-extract-test.yml
+++ b/.github/workflows/clien-extract-test.yml
@@ -97,7 +97,8 @@ jobs:
           --cli-binary-format raw-in-base64-out \
           --payload '{ "car_id": "test-github", "keywords": ["캐스퍼"], "date":"2025-02-10", "batch":3,"start_datetime": "2025-02-08T00:00:00", "end_datetime": "2025-02-11T00:00:00", "bucket": "${{ secrets.AWS_TEST_BUCKET_NAME }}"}' \
           response.json \
-          --region ap-northeast-2 
+          --region ap-northeast-2 \
+          --cli-read-timeout 840
         cat response.json
         
         # JSON에서 statusCode 추출

--- a/.github/workflows/dcinside-extract-test.yml
+++ b/.github/workflows/dcinside-extract-test.yml
@@ -100,7 +100,8 @@ jobs:
           --cli-binary-format raw-in-base64-out \
           --payload '{ "car_id": "test-github", "keywords": ["캐스퍼"], "date":"2025-02-10", "batch":3,"start_datetime": "2025-02-08T00:00:00", "end_datetime": "2025-02-11T00:00:00", "bucket": "${{ secrets.AWS_TEST_BUCKET_NAME }}"}' \
           response.json \
-          --region ap-northeast-2 
+          --region ap-northeast-2 \
+          --cli-read-timeout 840
         cat response.json       
         
         # JSON에서 statusCode 추출

--- a/.github/workflows/transform-sentiment-test.yml
+++ b/.github/workflows/transform-sentiment-test.yml
@@ -102,7 +102,8 @@ jobs:
           aws lambda invoke --function-name $TEST_LAMBDA_NAME \
             --cli-binary-format raw-in-base64-out \
             --payload "${PAYLOAD}" response.json \
-            --region ap-northeast-2
+            --region ap-northeast-2 \
+            --cli-read-timeout 840
           cat response.json
           
           STATUS_CODE=$(jq '.statusCode' response.json)


### PR DESCRIPTION
This update sets `--cli-read-timeout 840` for AWS CLI commands in multiple workflow files. It ensures longer-running invocations do not timeout, improving stability for tests with extended execution times.