### PR TITLE
fix: Update Lambda name in GitHub Actions workflow

### DIFF
--- a/.github/workflows/dcinside-extract-deploy.yml
+++ b/.github/workflows/dcinside-extract-deploy.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       TARGET_DIR: "extract/dcinside"
-      DEPLOY_LAMBDA_NAME: "vroomcast-lambda-extract-dc"
+      DEPLOY_LAMBDA_NAME: "vroomcast-lambda-extract-dcinside"
       DEPLOY_IMAGE_NAME: "extract-dc"
 
     steps:


### PR DESCRIPTION
Renamed the DEPLOY_LAMBDA_NAME environment variable to match the updated naming convention. This ensures consistency and clarity for deployment targets. No functional changes were made to the workflow.