### PR TITLE
feat: clien에서의 robots.txt의 요구사항에 맞게 제목으로만 크롤링 진행.

### DIFF
--- a/extract/clien/main.py
+++ b/extract/clien/main.py
@@ -56,15 +56,15 @@ def fetch_html(url: str) -> str:
     return ""
 
 
-def parse_rows(rows: list, start_datetime: datetime.datetime, end_datetime: datetime.datetime) -> dict[
+def parse_rows(rows: list, start_datetime: datetime, end_datetime: datetime) -> dict[
     str, tuple[str, str]]:
     """
     포스트 목록 html list를 받아서, 개별 url, title, 작성시간을 수집한다.
 
     Arguments:
         rows (list): 파싱이 필요한 html row list.
-        start_datetime (datetime.datetime): 해당 시간보다 크거나 같은 시간의 포스트 정보만 추출한다.
-        end_datetime (datetime.datetime): 해당 시간보다 작거나 같은 시간의 포스트 정보만 추출한다.
+        start_datetime (datetime): 해당 시간보다 크거나 같은 시간의 포스트 정보만 추출한다.
+        end_datetime (datetime): 해당 시간보다 작거나 같은 시간의 포스트 정보만 추출한다.
 
     Returns:
         dict: content_id를 key로 하고 value에 full_url과 content_title이 존재.

--- a/extract/clien/main.py
+++ b/extract/clien/main.py
@@ -105,7 +105,7 @@ def get_list_of_post_url(start_datetime: datetime, end_datetime: datetime, page_
     failed_page_number = []
     for page_number in page_number_list:
         # URL 생성 및 요청
-        search_url = BASE_URL + BOARD_URL + f"&po={page_number}" if page_number != 0 else ""
+        search_url = BASE_URL + BOARD_URL + (f"&po={page_number}" if page_number != 0 else "")
         html_content = fetch_html(search_url)
         if not html_content:
             logger.error(f"failed to fetch {search_url}")

--- a/extract/clien/main.py
+++ b/extract/clien/main.py
@@ -220,11 +220,12 @@ def main_crawler(keywords: list[str], start_datetime: str, end_datetime: str, da
 
     start_datetime = datetime.strptime(start_datetime, "%Y-%m-%dT%H:%M:%S")
     end_datetime = datetime.strptime(end_datetime, "%Y-%m-%dT%H:%M:%S")
-    urls, failed_page_number = get_list_of_post_url(start_datetime, end_datetime, range(0,50))
-    logger.info(f"Found {len(urls)} URLs.")
-    logger.info(f"Try failed page URLs.")
-    retried_urls, retried_failed_page_number = get_list_of_post_url(start_datetime, end_datetime, failed_page_number)
-    urls.update(retried_urls)
+    urls, failed_page_list = get_list_of_post_url(start_datetime, end_datetime, list(range(0,50)))
+    logger.info(f"Found {len(urls)} URLs. Failed page URLs: {failed_page_list}")
+    if failed_page_list:
+        logger.info(f"Try failed page URLs.")
+        retried_urls, retried_failed_page_list = get_list_of_post_url(start_datetime, end_datetime, failed_page_list)
+        urls.update(retried_urls)
     logger.info(f"Extracted {len(urls)} URLs.")
     total, success = load_each_post_with_keyword(keywords, urls, data_for_load_s3)
     logger.info(f"Extracted {total} URLs out of {success} URLs.")

--- a/extract/clien/main.py
+++ b/extract/clien/main.py
@@ -19,12 +19,25 @@ TRIAL_LIMIT = 10
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
+user_agent_list = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246",
+    "Mozilla/5.0 (X11; CrOS x86_64 8172.45.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.64 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/601.3.9 (KHTML, like Gecko) Version/9.0.2 Safari/601.3.9",
+    "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36",
+    "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/99.0.4844.84 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36 Edg/99.0.1150.36",
+    "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko",
+    "Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:99.0) Gecko/20100101 Firefox/99.0",
+]
+
 def fetch_html(url: str) -> str:
     """URL로부터 HTML 콘텐츠를 가져옵니다."""
     i = 0
     while i < TRIAL_LIMIT:
         try:
-            response = requests.get(url, headers={"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:135.0) Gecko/20100101 Firefox/135.0"}, allow_redirects=True)
+            response = requests.get(url, headers={"User-Agent": user_agent_list[i]})
             logger.info(f"{response.status_code} from {url}")
             if response.status_code != 200:
                 i += 1

--- a/extract/clien/parse_html.py
+++ b/extract/clien/parse_html.py
@@ -30,23 +30,17 @@ def normalize_text(text):
     return re.sub(r'\s+', ' ', text.replace("\xa0", " ")) if text else None
 
 
-def get_post_dict(html_file, file_id, url):
+def get_post_dict(html_file: str, file_id: int, url: str) -> dict | None:
     """
-    Parses the provided HTML content to extract post details along with associated metadata
-    and comments. The function processes elements inside a predefined content view tag,
-    extracting the post's title, date of creation, article content, and interaction metrics
-    such as view count, upvotes, and comment count. It also processes and structures the
-    comments into a list of dictionaries containing individual comment data like content,
-    reply status, timestamps, and upvote counts.
+    본문 html에서 필요한 부분을 파싱한다.
 
-    :param html_file: HTML content of the post
-    :type html_file: str
-    :param file_id: Unique identifier of the file or post
-    :type file_id: int
-    :param url: URL of the post
-    :type url: str
-    :return: A dictionary containing post details and comments or None if parsing fails
-    :rtype: dict or None
+    Args:
+        html_file (str): 포스트의 html content
+        file_id (int): 포스트의 식별자
+        url (str): 포스트의 url
+
+    Returns:
+        dict: 파싱에 성공한 데이터를 리턴한다. 파싱이 실패하면 None을 리턴.
     """
     try:
         soup = BeautifulSoup(html_file, "html.parser")


### PR DESCRIPTION
클리앙의 요구사항과 달라, 계속해서 크롤링이 막히던 문제를 robots.txt의 요구사항에 맞게, board endpoint 내에서 크롤링을 진행하도록 변경하였습니다.