### PR TITLE
fix: Update timestamp resolution to milliseconds in schema

### DIFF
--- a/transform/sentiment/main.py
+++ b/transform/sentiment/main.py
@@ -21,7 +21,7 @@ SCHEMA = pa.schema([
     ('source_id', pa.string()),       # VARCHAR(255)
     ('from_post', pa.bool_()),        # BOOLEAN
     ('sentence', pa.string()),        # VARCHAR(2048)
-    ('created_at', pa.timestamp('ns')),  # TIMESTAMP
+    ('created_at', pa.timestamp('ms')),  # TIMESTAMP
     ('sentiment', pa.int32())         # INT
 ])
 


### PR DESCRIPTION
Changed the `created_at` field from nanoseconds to milliseconds to match the desired timestamp precision. This ensures consistency with data processing requirements and avoids potential compatibility issues.